### PR TITLE
Use proper Postgres function instead of Workaround for existence operator

### DIFF
--- a/Query/JsonbExistence.php
+++ b/Query/JsonbExistence.php
@@ -9,9 +9,9 @@ use Doctrine\ORM\Query\Lexer;
 /**
  * Class JsonbExistence
  *
- * JsonbAtGreater ::= "JSONB_EX" "(" LeftHandSide "," RightHandSide ")"
+ * JsonbExistence ::= "JSONB_EX" "(" LeftHandSide "," RightHandSide ")"
  *
- * This will be converted to: "( LeftHandSide ? RightHandSide )"
+ * This will be converted to: "jsonb_exists( LeftHandSide, RightHandSide )"
  *
  * @package Boldtrn\JsonbBundle\Query
  * @author Robin Boldt <boldtrn@gmail.com>
@@ -34,9 +34,9 @@ class JsonbExistence extends FunctionNode
     public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
     {
         // We use a workaround to allow this statement in a WHERE. Doctrine relies on the existence of an ComparisonOperator
-        return '('.
-        $this->leftHandSide->dispatch($sqlWalker).' ? '.
-        $this->rightHandSide->dispatch($sqlWalker).
+        return 'jsonb_exists(' .
+        $this->leftHandSide->dispatch($sqlWalker) .', '.
+        $this->rightHandSide->dispatch($sqlWalker) .
         ')';
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Please make sure you have Postgresql with a version of at least 9.4 installed be
 The Bundle allows to create Jsonb fields and use the `@>`,`?` and the `#>>` operator on the Jsonb field.
 Other Operations can be easily added.
 
+The `?` operator is implemented by calling its function `jsonb_exists(column_name, value)` since Doctrine will consider it a parameter placeholder otherwise. The same must be done if you want to implement `?|` and `?&` operators, using `jsonb_exists_any(column_name, value)` and `jsonb_exists_all(column_name, value)` respectively
+
 I recently discovered the power of NativeQueries (http://doctrine-orm.readthedocs.org/en/latest/reference/native-sql.html).
 Right now I only use NativeQueries when querying. An example is shown below.
 

--- a/Tests/Query/JsonbExistenceTest.php
+++ b/Tests/Query/JsonbExistenceTest.php
@@ -26,7 +26,7 @@ class JsonbExistenceTest extends BaseTest
         "
             );
 
-        $expectedSQL = "SELECT t0.id AS id0, t0.attrs AS attrs1 FROM Test t0 WHERE (t0.attrs ? 'value') = true";
+        $expectedSQL = "SELECT t0.id AS id0, t0.attrs AS attrs1 FROM Test t0 WHERE jsonb_exists(t0.attrs, 'value') = true";
 
         $expectedSQL = str_replace("_", "", $expectedSQL);
 


### PR DESCRIPTION
While still investigating on the issue of the ? operators i have found this: http://stackoverflow.com/questions/30461558/jsonb-existential-operators-with-parameterised-queries

In other words, ?, ?| and ?& are aliases for the functions jsonb_exists, jsonb_exists_any and jsonb_exists_all respectively.  
I Think it's better to use these than the "(column->'value') IS NOT NULL" workaround since it doesn't exactly replicate "?" functionality (the ? operator will also find elements in a JSONB array while the workaround won't ) and the workaround doesn't use indexes either
