### PR TITLE
Do not translate falsy values to sql NULL.

### DIFF
--- a/Types/JsonbArrayType.php
+++ b/Types/JsonbArrayType.php
@@ -27,16 +27,4 @@ class JsonbArrayType extends JsonArrayType
         return 'jsonb';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function convertToDatabaseValue($value, AbstractPlatform $platform)
-    {
-        if (null === $value || empty($value)) {
-            return null;
-        }
-
-        return json_encode($value);
-    }
-
 }


### PR DESCRIPTION
Hello,

Can we talk about the reason you decided to translate empty arrays to sql NULLs in b69017a03d290b9edc3a76ccc03e9e2a568895ee?

I know that Doctrine translates sql NULLs to empty arrays during hydration, but I think it's desirable to actually store "[]" instead of NULLs in the db for raw SQL reasons.

E.g. this:

``` sql
SELECT 
  jsonb_array_length(col1)
FROM ( VALUES 
    ('[1, 2, 3]'::JSONB),
    ('[4, 5, 6]'::JSONB),
    ('[7, 8]'::JSONB),
    ('[9, 10, 11, 14]'::JSONB),
    (NULL::JSONB)
  ) AS "table"(col1)
;
```

will return this:

```
3, 3, 2, 4, NULL
```

I would expect to get

```
3, 3, 2, 4, 0
```

But this is just how NULLs are handled in SQL.

I can see how this could cause issues for me. E.g. if I want to find a record, which has a `string[]` field with a length of 0, then this wouldn't work:

``` sql
SELECT * FROM "user" WHERE jsonb_array_length(roles) = 0;
```

I would need to remember that I need to run this instead:

``` sql
SELECT * FROM "user" WHERE jsonb_array_length(roles) IS NULL;
// or
SELECT * FROM "user" WHERE roles IS NULL;
```

Things get even dirtier if we think of aggregate functions here:

``` sql
SELECT
  jsonb_array_length(col1) AS first_column, COUNT(*)
FROM ( VALUES
    ('[1, 2, 3]'::JSONB),
    ('[4, 5, 6]'::JSONB),
    ('[7, 8]'::JSONB),
    ('[9, 10, 11, 14]'::JSONB),
    (NULL::JSONB)
  ) AS "table"(col1)
GROUP BY (first_column);
```

Produces:

```
NULL,1
4,1
2,1
3,2
```

Instead of:

```
0,1
4,1
2,1
3,2
```

Dealing with NULLs instead of '[]' is just too much hassle. I know it's cheaper to store NULLs than '[]', but in my opinion the memory optimization is not worth the burden of maintenance (remembering, that we can get NULLs in places, when we'd expect integers).

What do you think about reverting your commit? 
