### PR TITLE
Use JsonType instead of JsonArrayType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.5
+  - 7.3
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 
 before_script:
   - psql -c 'create database jsonb_test;' -U postgres

--- a/Types/JsonbArrayType.php
+++ b/Types/JsonbArrayType.php
@@ -2,14 +2,14 @@
 namespace Boldtrn\JsonbBundle\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\JsonArrayType;
+use Doctrine\DBAL\Types\JsonType;
 
 /**
  * Array Type which can be used to generate jsonb arrays. It uses the Doctrine JsonArrayType
  *
  * @author Robin Boldt <boldtrn@gmail.com>
  */
-class JsonbArrayType extends JsonArrayType
+class JsonbArrayType extends JsonType
 {
     /**
      * {@inheritdoc}
@@ -25,6 +25,14 @@ class JsonbArrayType extends JsonArrayType
     public function getName()
     {
         return 'jsonb';
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
     }
 
 }


### PR DESCRIPTION
To be compliant with Symfony 4.2 (and furthermore to avoid deprecation in Symfony5.0)